### PR TITLE
Change card to use atoms for face cards

### DIFF
--- a/lib/pokerwars/card.ex
+++ b/lib/pokerwars/card.ex
@@ -1,8 +1,6 @@
 defmodule Pokerwars.Card do
-  # Ranks of numbered cars are represented by the number (2..10)
-  # Jack, Queen, King, Ace represented by 11, 12, 13, 14 respectively
-
-  # Suits can be: :hearts, :diamonds, :clubs, :spades
+  # Ranks can be: 2..10 | :jack | :queen | :king | :ace
+  # Suits can be: :hearts | :diamonds | :clubs | :spades
 
   defstruct [:rank, :suit]
 end

--- a/test/pokerwars/hand_test.exs
+++ b/test/pokerwars/hand_test.exs
@@ -7,10 +7,10 @@ defmodule Pokerwars.HandTest do
   test "evaluates royal flush of hearts" do
     cards = [
       %Card{rank: 10, suit: :hearts},
-      %Card{rank: 11, suit: :hearts},
-      %Card{rank: 12, suit: :hearts},
-      %Card{rank: 13, suit: :hearts},
-      %Card{rank: 14, suit: :hearts}
+      %Card{rank: :jack, suit: :hearts},
+      %Card{rank: :queen, suit: :hearts},
+      %Card{rank: :king, suit: :hearts},
+      %Card{rank: :ace, suit: :hearts}
     ]
 
     assert Hand.score(cards) == :royal_flush
@@ -19,10 +19,10 @@ defmodule Pokerwars.HandTest do
   test "evaluates royal flush of spades" do
     cards = [
       %Card{rank: 10, suit: :spades},
-      %Card{rank: 11, suit: :spades},
-      %Card{rank: 12, suit: :spades},
-      %Card{rank: 13, suit: :spades},
-      %Card{rank: 14, suit: :spades}
+      %Card{rank: :jack, suit: :spades},
+      %Card{rank: :queen, suit: :spades},
+      %Card{rank: :king, suit: :spades},
+      %Card{rank: :ace, suit: :spades}
     ]
 
     assert Hand.score(cards) == :royal_flush
@@ -31,13 +31,37 @@ defmodule Pokerwars.HandTest do
   test "does not evaluate royal flush for mismatching suits" do
     cards = [
       %Card{rank: 10, suit: :diamonds},
-      %Card{rank: 11, suit: :diamonds},
-      %Card{rank: 12, suit: :diamonds},
-      %Card{rank: 13, suit: :clubs},
-      %Card{rank: 14, suit: :clubs}
+      %Card{rank: :jack, suit: :diamonds},
+      %Card{rank: :queen, suit: :diamonds},
+      %Card{rank: :king, suit: :clubs},
+      %Card{rank: :ace, suit: :clubs}
     ]
 
     assert Hand.score(cards) != :royal_flush
+  end
+
+  test "evaluates straight flush" do
+    cards = [
+      %Card{rank: 3, suit: :clubs},
+      %Card{rank: 4, suit: :clubs},
+      %Card{rank: 5, suit: :clubs},
+      %Card{rank: 6, suit: :clubs},
+      %Card{rank: 7, suit: :clubs}
+    ]
+
+    assert Hand.score(cards) == :straight_flush
+  end
+
+  test "evaluates straight flush starting from ace" do
+    cards = [
+      %Card{rank: :ace, suit: :clubs},
+      %Card{rank: 2, suit: :clubs},
+      %Card{rank: 3, suit: :clubs},
+      %Card{rank: 4, suit: :clubs},
+      %Card{rank: 5, suit: :clubs}
+    ]
+
+    assert Hand.score(cards) == :straight_flush
   end
 
   test "evaluates high card" do
@@ -46,7 +70,7 @@ defmodule Pokerwars.HandTest do
       %Card{rank: 3, suit: :hearts},
       %Card{rank: 5, suit: :diamonds},
       %Card{rank: 7, suit: :spades},
-      %Card{rank: 11, suit: :spades}
+      %Card{rank: :jack, suit: :spades}
     ]
 
     assert Hand.score(cards) == :high_card


### PR DESCRIPTION
I think this data representation is better for two reasons:

* the value that we used to assign to the cards is our own ranking that we use to assign value to the hands, but it does not really belong to the card itself
* by using atoms, we can describe better the cases when we have straights starting from the low ace.

The disadvantage is that players will have to do the conversion from rank to their 'score' themselves.

Thoughts?