### PR TITLE
Add logic for comparing poker hands

### DIFF
--- a/lib/pokerwars/card.ex
+++ b/lib/pokerwars/card.ex
@@ -1,8 +1,20 @@
 defmodule Pokerwars.Card do
-  # Ranks of numbered cars are represented by the number (2..10)
-  # Jack, Queen, King, Ace represented by 11, 12, 13, 14 respectively
+  @moduledoc """
+  Provides a set of functions for parsing and processing representation of cards.
 
-  # Suits can be: :hearts, :diamonds, :clubs, :spades
+  Ranks of numbered cards are represented by the number (2..10).
+  Jack, Queen, King, Ace represented by 11, 12, 13, 14 respectively.
+  Suits can be: :hearts, :diamonds, :clubs, :spades.
+
+  ### Example
+
+    iex> Card.parse("Jd")
+    %Pokerwars.Card{rank: 11, suit: :diamonds}
+
+    iex> Card.print(%Pokerwars.Card{rank: 14, suit: :diamonds})
+    "Ad"
+
+  """
 
   defstruct [:suit, :rank]
 
@@ -12,7 +24,7 @@ defmodule Pokerwars.Card do
 
   def parse(card_string) do
     card_regex = ~r/(.{1,2})([hdsc])/
-    [[_,face,suit]] = Regex.scan(card_regex, card_string)
+    [[_, face, suit]] = Regex.scan(card_regex, card_string)
     %Pokerwars.Card{rank: parse_rank(face), suit: parse_suit(suit)}
   end
 

--- a/lib/pokerwars/dealer.ex
+++ b/lib/pokerwars/dealer.ex
@@ -1,0 +1,125 @@
+defmodule Pokerwars.Dealer do
+  @moduledoc """
+  Provides a set of functions for comparing poker hands.
+
+  ### Example
+
+    iex> three_of_a_hand = [%Pokerwars.Card{rank: 3, suit: :diamonds},
+    ...> %Pokerwars.Card{rank: 4, suit: :spades},
+    ...> %Pokerwars.Card{rank: 14, suit: :spades},
+    ...> %Pokerwars.Card{rank: 14, suit: :hearts},
+    ...> %Pokerwars.Card{rank: 14, suit: :clubs}]
+    iex> straight = [%Pokerwars.Card{rank: 14, suit: :spades},
+    ...> %Pokerwars.Card{rank: 3, suit: :spades},
+    ...> %Pokerwars.Card{rank: 2, suit: :clubs},
+    ...> %Pokerwars.Card{rank: 5, suit: :diamonds},
+    ...> %Pokerwars.Card{rank: 4, suit: :hearts}]
+    iex> Dealer.stronger_hand(straight, three_of_a_hand)
+    [%Pokerwars.Card{rank: 14, suit: :spades},
+     %Pokerwars.Card{rank: 3, suit: :spades},
+     %Pokerwars.Card{rank: 2, suit: :clubs},
+     %Pokerwars.Card{rank: 5, suit: :diamonds},
+     %Pokerwars.Card{rank: 4, suit: :hearts}]
+
+  """
+
+  alias Pokerwars.Hand
+
+  @hands_scores %{
+    straight_flush: 9,
+    four_of_a_kind: 8,
+    full_house: 7,
+    flush: 6,
+    straight: 5,
+    three_of_a_kind: 4,
+    two_pair: 3,
+    pair: 2,
+    high_card: 1
+  }
+
+  @doc """
+  Returns the stronger hand.
+  """
+  def stronger_hand(a, a), do: a
+  def stronger_hand(left_hand, right_hand) do
+    do_stronger_hand(
+      {left_hand, Hand.score(left_hand)},
+      {right_hand, Hand.score(right_hand)}
+    )
+  end
+
+  defp do_stronger_hand({left_hand, left_hand_type}, {right_hand, right_hand_type}) do
+    cond do
+      @hands_scores[left_hand_type] > @hands_scores[right_hand_type] ->
+        left_hand
+      @hands_scores[left_hand_type] < @hands_scores[right_hand_type] ->
+        right_hand
+      true ->
+        stronger_rank_hand(Enum.sort(left_hand), Enum.sort(right_hand), left_hand_type)
+    end
+  end
+
+  # straight and straight flush cases with Ace
+  defp stronger_rank_hand([%{rank: 2}, _, _, _, %{rank: 14}], [%{rank: 2}, _, _, _, %{rank: 14}], type) when type in [:straight, :straight_flush], do: :split_pot
+  defp stronger_rank_hand([%{rank: 2}, _, _, _, %{rank: 14}], hand, type) when type in [:straight, :straight_flush], do: hand
+  defp stronger_rank_hand(hand, [%{rank: 2}, _, _, _, %{rank: 14}], type) when type in [:straight, :straight_flush], do: hand
+
+  defp stronger_rank_hand(left_hand, right_hand, hand_type) when hand_type in [:high_card, :straight, :flush, :straight_flush] do
+    left_sorted_ranks = left_hand |> Enum.map(&(&1.rank)) |> Enum.sort(&(&1 >= &2))
+    right_sorted_ranks = right_hand |> Enum.map(&(&1.rank)) |> Enum.sort(&(&1 >= &2))
+
+    case compare_ordered_ranks(left_sorted_ranks, right_sorted_ranks) do
+      1 -> left_hand
+      -1 -> right_hand
+      _ -> :split_pot
+    end
+  end
+  defp stronger_rank_hand(left_hand, right_hand, :pair), do: do_stronger_rank_hand(left_hand, right_hand, :high_card)
+  defp stronger_rank_hand(left_hand, right_hand, :two_pair), do: do_stronger_rank_hand(left_hand, right_hand, :pair)
+  defp stronger_rank_hand(left_hand, right_hand, :three_of_a_kind), do: do_stronger_rank_hand(left_hand, right_hand, :high_card)
+  defp stronger_rank_hand(left_hand, right_hand, :full_house), do: do_stronger_rank_hand(left_hand, right_hand, :pair)
+  defp stronger_rank_hand(left_hand, right_hand, :four_of_a_kind), do: do_stronger_rank_hand(left_hand, right_hand, :high_card)
+
+  defp do_stronger_rank_hand(left_hand, right_hand, hand_type_for_recursion) do
+    left_pair_card = extract_highest_same(left_hand)
+    right_pair_card = extract_highest_same(right_hand)
+
+    cond do
+      left_pair_card.rank > right_pair_card.rank -> left_hand
+      left_pair_card.rank < right_pair_card.rank -> right_hand
+      true ->
+        # exclude n-of-a-kind card and continue with the rest
+        reduced_left_hand = left_hand |> Enum.filter(&(left_pair_card.rank != &1.rank))
+        reduced_right_hand = right_hand |> Enum.filter(&(right_pair_card.rank != &1.rank))
+
+        case stronger_rank_hand(reduced_left_hand, reduced_right_hand, hand_type_for_recursion) do
+          ^reduced_left_hand -> left_hand
+          ^reduced_right_hand -> right_hand
+          _ -> :split_pot
+        end
+    end
+  end
+
+  defp extract_highest_same(hand) do
+    [{max_card, max_frequence} | hand_tail] =
+      hand
+      |> Enum.group_by(&(&1.rank))
+      |> Enum.map(fn {rank, cards} -> {hd(cards), length(cards)} end)
+      |> Enum.sort_by(fn {card, repetitions} -> -repetitions end)
+
+    # this step is needed for the case of two pairs
+    {possible_max_card, possible_max_frequence} = Enum.at(hand_tail, 0, {nil, 0}) # defaults to {nil, 0} when hand_tail empty
+    cond do
+      max_frequence == possible_max_frequence ->
+        if possible_max_card.rank > max_card.rank, do: possible_max_card, else: max_card
+      true -> max_card
+    end
+  end
+
+  defp compare_ordered_ranks([], []), do: 0
+  defp compare_ordered_ranks([left_kicker | _], [right_kicker | _]) when left_kicker > right_kicker, do: 1
+  defp compare_ordered_ranks([left_kicker | _], [right_kicker | _]) when left_kicker < right_kicker, do: -1
+  defp compare_ordered_ranks([_ | left_ranks_tail], [_ | right_ranks_tail]) do
+    compare_ordered_ranks(left_ranks_tail, right_ranks_tail)
+  end
+end

--- a/lib/pokerwars/hand.ex
+++ b/lib/pokerwars/hand.ex
@@ -4,7 +4,7 @@ defmodule Pokerwars.Hand do
 
   ### Example
 
-    iex> Pokerwars.Hand.parse_cards("As 10s Jc Kd Qh")
+    iex> Pokerwars.Hand.parse("As 10s Jc Kd Qh")
     [%Pokerwars.Card{rank: 14, suit: :spades},
      %Pokerwars.Card{rank: 10, suit: :spades},
      %Pokerwars.Card{rank: 11, suit: :clubs},
@@ -26,7 +26,7 @@ defmodule Pokerwars.Hand do
     calculate_score(cards)
   end
 
-  def parse_cards(card_strings) do
+  def parse(card_strings) do
     card_strings
     |> String.split(" ")
     |> Enum.map(&(Pokerwars.Card.parse(&1)))

--- a/lib/pokerwars/hand.ex
+++ b/lib/pokerwars/hand.ex
@@ -1,7 +1,35 @@
 defmodule Pokerwars.Hand do
+  @moduledoc """
+  Provides a set of functions that process hand of cards.
+
+  ### Example
+
+    iex> Pokerwars.Hand.parse_cards("As 10s Jc Kd Qh")
+    [%Pokerwars.Card{rank: 14, suit: :spades},
+     %Pokerwars.Card{rank: 10, suit: :spades},
+     %Pokerwars.Card{rank: 11, suit: :clubs},
+     %Pokerwars.Card{rank: 13, suit: :diamonds},
+     %Pokerwars.Card{rank: 12, suit: :hearts}]
+
+    iex> hand = [%Pokerwars.Card{rank: 14, suit: :spades},
+    ...> %Pokerwars.Card{rank: 10, suit: :spades},
+    ...> %Pokerwars.Card{rank: 11, suit: :clubs},
+    ...> %Pokerwars.Card{rank: 13, suit: :diamonds},
+    ...> %Pokerwars.Card{rank: 12, suit: :hearts}]
+    iex> Pokerwars.Hand.score(hand)
+    :straight
+
+  """
+
   def score(cards) do
     cards = Enum.sort(cards)
     calculate_score(cards)
+  end
+
+  def parse_cards(card_strings) do
+    card_strings
+    |> String.split(" ")
+    |> Enum.map(&(Pokerwars.Card.parse(&1)))
   end
 
   defp calculate_score(cards) do
@@ -61,7 +89,7 @@ defmodule Pokerwars.Hand do
   defp flush?(cards) do
     suits = extract_suits(cards)
     case suits do
-      [a,a,a,a,a] -> true
+      [a, a, a, a, a] -> true
       _ -> false
     end
   end
@@ -69,7 +97,7 @@ defmodule Pokerwars.Hand do
   defp straight?(cards) do
     ranks = extract_ranks(cards)
 
-    ranks == [2,3,4,5,14] or
+    ranks == [2, 3, 4, 5, 14] or
     consecutive?(ranks)
   end
 

--- a/test/pokerwars/dealer_test.exs
+++ b/test/pokerwars/dealer_test.exs
@@ -1,0 +1,203 @@
+defmodule Pokerwars.DealerTest do
+  use ExUnit.Case, async: true
+  import Pokerwars.TestHelpers
+  alias Pokerwars.{Hand, Dealer}
+
+  doctest Pokerwars.Dealer
+
+  describe "compare different hands" do
+    test "pair is stronger than high card hand" do
+      high_hand = Hand.parse_cards("2s 3h 5d 7s Js")
+      one_pair_hand = Hand.parse_cards("3s 4d 10h 8s 8d")
+
+      assert_set_equal(Dealer.stronger_hand(high_hand, one_pair_hand), one_pair_hand)
+    end
+
+    test "two pairs are stronger than one pair" do
+      one_pair_hand = Hand.parse_cards("3s 4d 10h 8s 8d")
+      two_pairs_hand = Hand.parse_cards("3s 3h Ad As 5h")
+
+      assert_set_equal(Dealer.stronger_hand(two_pairs_hand, one_pair_hand), two_pairs_hand)
+    end
+
+    test "three of a kind are stronger than two pairs" do
+      three_of_a_hand = Hand.parse_cards("3d 4s As Ah Ac")
+      two_pairs_hand = Hand.parse_cards("3s 3h Ad As 5h")
+
+      assert_set_equal(Dealer.stronger_hand(two_pairs_hand, three_of_a_hand), three_of_a_hand)
+    end
+
+    test "straight is stronger than three of a kind" do
+      three_of_a_hand = Hand.parse_cards("3d 4s As Ah Ac")
+      straight = Hand.parse_cards("As 3s 2c 5d 4h")
+
+      assert_set_equal(Dealer.stronger_hand(straight, three_of_a_hand), straight)
+    end
+
+    test "flush is stronger than Straight" do
+      flush = Hand.parse_cards("8h 2h Ah 9h 4h")
+      straight = Hand.parse_cards("As 3s 2c 5d 4h")
+
+      assert_set_equal(Dealer.stronger_hand(straight, flush), flush)
+    end
+
+    test "full-house is stronger than flush" do
+      flush = Hand.parse_cards("8h 2h Ah 9h 4h")
+      full_house = Hand.parse_cards("3s 3h 3c Ad As")
+
+      assert_set_equal(Dealer.stronger_hand(full_house, flush), full_house)
+    end
+
+    test "four of a kind are stronger than full-house" do
+      four_of_a_kind = Hand.parse_cards("7h 7d 7s 4s 7c")
+      full_house = Hand.parse_cards("3s 3h 3c Ad As")
+
+      assert_set_equal(Dealer.stronger_hand(full_house, four_of_a_kind), four_of_a_kind)
+    end
+
+    test "straight flush is stronger than four of a kind" do
+      four_of_a_kind = Hand.parse_cards("7h 7d 7s 4s 7c")
+      straight = Hand.parse_cards("Ad 10d 11d 13d 12d")
+
+      assert_set_equal(Dealer.stronger_hand(straight, four_of_a_kind), straight)
+    end
+  end
+
+  describe "compare same hands" do
+    test "high card hand with higher highest card is stronger" do
+      high_hand = Hand.parse_cards("2s 3h 5d 7s Js")
+      higher_high_hand = Hand.parse_cards("Ks 8h 6d 3s Jh")
+
+      assert_set_equal(Dealer.stronger_hand(higher_high_hand, high_hand), higher_high_hand)
+    end
+
+    test "high card hand with third highest card is stronger" do
+      high_hand = Hand.parse_cards("Kh 3h 5d 7s Js")
+      higher_high_hand = Hand.parse_cards("Ks 8h 6d 3s Jh")
+
+      assert_set_equal(Dealer.stronger_hand(higher_high_hand, high_hand), higher_high_hand)
+    end
+
+    test "splits the pot when high card hands are equal" do
+      high_hand_1 = Hand.parse_cards("Kh 3h 5d 7s Js")
+      high_hand_2 = Hand.parse_cards("Ks 3d 5h 7h Jh")
+
+      assert Dealer.stronger_hand(high_hand_1, high_hand_2) == :split_pot
+    end
+
+    test "the pair hand with the highest pair is stronger" do
+      pair_hand = Hand.parse_cards("3s 3h Ad Ks 5h")
+      higher_pair_hand = Hand.parse_cards("3s 6h Qd 2s 6s")
+
+      assert_set_equal(Dealer.stronger_hand(higher_pair_hand, pair_hand), higher_pair_hand)
+    end
+
+    test "the pair hand with the highest kicker is stronger when the pairs are equal" do
+      higher_kicker_pair_hand = Hand.parse_cards("3s 3h Ad Ks 5h")
+      pair_hand = Hand.parse_cards("3d 6h Qd As 3c")
+
+      assert_set_equal(Dealer.stronger_hand(pair_hand, higher_kicker_pair_hand), higher_kicker_pair_hand)
+    end
+
+    test "the two-pair hand with the highest pair is stronger" do
+      two_pair_hand = Hand.parse_cards("3d 6s 6h 10s 10h")
+      better_two_pair_hand = Hand.parse_cards("2d 5c 5d Jc Jd")
+
+      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+    end
+
+    test "the two-pair hand with the highest second pair is stronger when the first are equal" do
+      two_pair_hand = Hand.parse_cards("Jd 5s 5h 10s 10h")
+      better_two_pair_hand = Hand.parse_cards("3d 6c 6d 10c 10d")
+
+      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+    end
+
+    test "the two-pair hand with the highest kicker is stronger when both pairs are equal" do
+      two_pair_hand = Hand.parse_cards("3d 5s 5h 10s 10h")
+      better_two_pair_hand = Hand.parse_cards("Qd 5c 5d 10c 10d")
+
+      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+    end
+
+    test "the three-of-a-kind hand with the highest three-of-a-kind is stronger" do
+      three_of_a_kind_hand = Hand.parse_cards("7h 3d 7s 4s 7c")
+      better_three_of_a_kind_hand = Hand.parse_cards("3d 4s Qs Qh Qc")
+
+      assert_set_equal(Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand), better_three_of_a_kind_hand)
+    end
+
+    test "the straight hand with the highest rank card is stronger" do
+      straight_hand = Hand.parse_cards("6s 3s 2c 5d 4h")
+      better_straight_hand = Hand.parse_cards("Js 8s 10c 7d 9h")
+
+      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+    end
+
+    test "the straight hand with the highest rank card is stronger when Ace is used as 1" do
+      straight_hand = Hand.parse_cards("As 2d 3c 4h 5s")
+      better_straight_hand = Hand.parse_cards("9s 10s Jc Kd Qh")
+
+      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+    end
+
+    test "the straight hand with the highest rank of Ace is stronger when Aces are used as 1 and 14" do
+      straight_hand = Hand.parse_cards("As 2d 3c 4h 5s")
+      better_straight_hand = Hand.parse_cards("As 10s Jc Kd Qh")
+
+      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+    end
+
+    test "the flush hand with the highest rank card is stronger" do
+      flush_hand = Hand.parse_cards("8h 2h Jh 7h 4h")
+      better_flush_hand = Hand.parse_cards("3d 2d Ad 9d 4d")
+
+      assert_set_equal(Dealer.stronger_hand(flush_hand, better_flush_hand), better_flush_hand)
+    end
+
+    test "the full-house hand with the highest three matching cards is stronger" do
+      full_house_hand = Hand.parse_cards("3s 3h 3c Ad As")
+      better_full_house_hand = Hand.parse_cards("Js Jh Jc 6d 6s")
+
+      assert_set_equal(Dealer.stronger_hand(full_house_hand, better_full_house_hand), better_full_house_hand)
+    end
+
+    test "the four-of-a-kind hand with the highest four-of-a-kind is stronger" do
+      four_of_a_kind_hand = Hand.parse_cards("3s 3h 3c 3d As")
+      better_four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d 6s")
+
+      assert_set_equal(Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand), better_four_of_a_kind_hand)
+    end
+
+    test "the straight-flush hand with the highest straight-flush is stronger" do
+      straight_flush = Hand.parse_cards("Ah 3h 2h 5h 4h")
+      better_straight_flush = Hand.parse_cards("Jh 8h 10h 7h 9h")
+
+      assert_set_equal(Dealer.stronger_hand(straight_flush, better_straight_flush), better_straight_flush)
+    end
+  end
+
+  describe "Community card game" do
+    # At the moment works out of the box without any additional code.
+    test "the three-of-a-kind hand with the highest kicker is stronger when the three-of-a-kind are equal" do
+      three_of_a_kind_hand = Hand.parse_cards("7h 3d 7s Js 7c")
+      better_three_of_a_kind_hand = Hand.parse_cards("5d Jd 7s 7h 7c")
+
+      assert_set_equal(Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand), better_three_of_a_kind_hand)
+    end
+
+    test "the full-house hand with the highest two matching cards is stronger when the full-house are equal" do
+      full_house_hand = Hand.parse_cards("3s 3h 3c Qd Qs")
+      better_full_house_hand = Hand.parse_cards("3d 3s 3c Kd Ks")
+
+      assert_set_equal(Dealer.stronger_hand(full_house_hand, better_full_house_hand), better_full_house_hand)
+    end
+
+    test "the four-of-a-kind hand with the highest kicker is stronger when the four-of-a-kind are equal" do
+      four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d Js")
+      better_four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d Ks")
+
+      assert_set_equal(Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand), better_four_of_a_kind_hand)
+    end
+  end
+end

--- a/test/pokerwars/dealer_test.exs
+++ b/test/pokerwars/dealer_test.exs
@@ -1,203 +1,203 @@
 defmodule Pokerwars.DealerTest do
   use ExUnit.Case, async: true
-  import Pokerwars.TestHelpers
+
   alias Pokerwars.{Hand, Dealer}
 
   doctest Pokerwars.Dealer
 
   describe "compare different hands" do
     test "pair is stronger than high card hand" do
-      high_hand = Hand.parse_cards("2s 3h 5d 7s Js")
-      one_pair_hand = Hand.parse_cards("3s 4d 10h 8s 8d")
+      high_hand = Hand.parse("2s 3h 5d 7s Js")
+      one_pair_hand = Hand.parse("3s 4d 10h 8s 8d")
 
-      assert_set_equal(Dealer.stronger_hand(high_hand, one_pair_hand), one_pair_hand)
+      assert Dealer.stronger_hand(high_hand, one_pair_hand) == one_pair_hand
     end
 
     test "two pairs are stronger than one pair" do
-      one_pair_hand = Hand.parse_cards("3s 4d 10h 8s 8d")
-      two_pairs_hand = Hand.parse_cards("3s 3h Ad As 5h")
+      one_pair_hand = Hand.parse("3s 4d 10h 8s 8d")
+      two_pairs_hand = Hand.parse("3s 3h Ad As 5h")
 
-      assert_set_equal(Dealer.stronger_hand(two_pairs_hand, one_pair_hand), two_pairs_hand)
+      assert Dealer.stronger_hand(two_pairs_hand, one_pair_hand) == two_pairs_hand
     end
 
     test "three of a kind are stronger than two pairs" do
-      three_of_a_hand = Hand.parse_cards("3d 4s As Ah Ac")
-      two_pairs_hand = Hand.parse_cards("3s 3h Ad As 5h")
+      three_of_a_hand = Hand.parse("3d 4s As Ah Ac")
+      two_pairs_hand = Hand.parse("3s 3h Ad As 5h")
 
-      assert_set_equal(Dealer.stronger_hand(two_pairs_hand, three_of_a_hand), three_of_a_hand)
+      assert Dealer.stronger_hand(two_pairs_hand, three_of_a_hand) == three_of_a_hand
     end
 
     test "straight is stronger than three of a kind" do
-      three_of_a_hand = Hand.parse_cards("3d 4s As Ah Ac")
-      straight = Hand.parse_cards("As 3s 2c 5d 4h")
+      three_of_a_hand = Hand.parse("3d 4s As Ah Ac")
+      straight = Hand.parse("As 3s 2c 5d 4h")
 
-      assert_set_equal(Dealer.stronger_hand(straight, three_of_a_hand), straight)
+      assert Dealer.stronger_hand(straight, three_of_a_hand) == straight
     end
 
     test "flush is stronger than Straight" do
-      flush = Hand.parse_cards("8h 2h Ah 9h 4h")
-      straight = Hand.parse_cards("As 3s 2c 5d 4h")
+      flush = Hand.parse("8h 2h Ah 9h 4h")
+      straight = Hand.parse("As 3s 2c 5d 4h")
 
-      assert_set_equal(Dealer.stronger_hand(straight, flush), flush)
+      assert Dealer.stronger_hand(straight, flush) == flush
     end
 
     test "full-house is stronger than flush" do
-      flush = Hand.parse_cards("8h 2h Ah 9h 4h")
-      full_house = Hand.parse_cards("3s 3h 3c Ad As")
+      flush = Hand.parse("8h 2h Ah 9h 4h")
+      full_house = Hand.parse("3s 3h 3c Ad As")
 
-      assert_set_equal(Dealer.stronger_hand(full_house, flush), full_house)
+      assert Dealer.stronger_hand(full_house, flush) == full_house
     end
 
     test "four of a kind are stronger than full-house" do
-      four_of_a_kind = Hand.parse_cards("7h 7d 7s 4s 7c")
-      full_house = Hand.parse_cards("3s 3h 3c Ad As")
+      four_of_a_kind = Hand.parse("7h 7d 7s 4s 7c")
+      full_house = Hand.parse("3s 3h 3c Ad As")
 
-      assert_set_equal(Dealer.stronger_hand(full_house, four_of_a_kind), four_of_a_kind)
+      assert Dealer.stronger_hand(full_house, four_of_a_kind) == four_of_a_kind
     end
 
     test "straight flush is stronger than four of a kind" do
-      four_of_a_kind = Hand.parse_cards("7h 7d 7s 4s 7c")
-      straight = Hand.parse_cards("Ad 10d 11d 13d 12d")
+      four_of_a_kind = Hand.parse("7h 7d 7s 4s 7c")
+      straight = Hand.parse("Ad 10d 11d 13d 12d")
 
-      assert_set_equal(Dealer.stronger_hand(straight, four_of_a_kind), straight)
+      assert Dealer.stronger_hand(straight, four_of_a_kind) == straight
     end
   end
 
   describe "compare same hands" do
     test "high card hand with higher highest card is stronger" do
-      high_hand = Hand.parse_cards("2s 3h 5d 7s Js")
-      higher_high_hand = Hand.parse_cards("Ks 8h 6d 3s Jh")
+      high_hand = Hand.parse("2s 3h 5d 7s Js")
+      higher_high_hand = Hand.parse("Ks 8h 6d 3s Jh")
 
-      assert_set_equal(Dealer.stronger_hand(higher_high_hand, high_hand), higher_high_hand)
+      assert Dealer.stronger_hand(higher_high_hand, high_hand) == higher_high_hand
     end
 
     test "high card hand with third highest card is stronger" do
-      high_hand = Hand.parse_cards("Kh 3h 5d 7s Js")
-      higher_high_hand = Hand.parse_cards("Ks 8h 6d 3s Jh")
+      high_hand = Hand.parse("Kh 3h 5d 7s Js")
+      higher_high_hand = Hand.parse("Ks 8h 6d 3s Jh")
 
-      assert_set_equal(Dealer.stronger_hand(higher_high_hand, high_hand), higher_high_hand)
+      assert Dealer.stronger_hand(higher_high_hand, high_hand) == higher_high_hand
     end
 
     test "splits the pot when high card hands are equal" do
-      high_hand_1 = Hand.parse_cards("Kh 3h 5d 7s Js")
-      high_hand_2 = Hand.parse_cards("Ks 3d 5h 7h Jh")
+      high_hand_1 = Hand.parse("Kh 3h 5d 7s Js")
+      high_hand_2 = Hand.parse("Ks 3d 5h 7h Jh")
 
       assert Dealer.stronger_hand(high_hand_1, high_hand_2) == :split_pot
     end
 
     test "the pair hand with the highest pair is stronger" do
-      pair_hand = Hand.parse_cards("3s 3h Ad Ks 5h")
-      higher_pair_hand = Hand.parse_cards("3s 6h Qd 2s 6s")
+      pair_hand = Hand.parse("3s 3h Ad Ks 5h")
+      higher_pair_hand = Hand.parse("3s 6h Qd 2s 6s")
 
-      assert_set_equal(Dealer.stronger_hand(higher_pair_hand, pair_hand), higher_pair_hand)
+      assert Dealer.stronger_hand(higher_pair_hand, pair_hand) == higher_pair_hand
     end
 
     test "the pair hand with the highest kicker is stronger when the pairs are equal" do
-      higher_kicker_pair_hand = Hand.parse_cards("3s 3h Ad Ks 5h")
-      pair_hand = Hand.parse_cards("3d 6h Qd As 3c")
+      higher_kicker_pair_hand = Hand.parse("3s 3h Ad Ks 5h")
+      pair_hand = Hand.parse("3d 6h Qd As 3c")
 
-      assert_set_equal(Dealer.stronger_hand(pair_hand, higher_kicker_pair_hand), higher_kicker_pair_hand)
+      assert Dealer.stronger_hand(pair_hand, higher_kicker_pair_hand) == higher_kicker_pair_hand
     end
 
     test "the two-pair hand with the highest pair is stronger" do
-      two_pair_hand = Hand.parse_cards("3d 6s 6h 10s 10h")
-      better_two_pair_hand = Hand.parse_cards("2d 5c 5d Jc Jd")
+      two_pair_hand = Hand.parse("3d 6s 6h 10s 10h")
+      better_two_pair_hand = Hand.parse("2d 5c 5d Jc Jd")
 
-      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+      assert Dealer.stronger_hand(two_pair_hand, better_two_pair_hand) == better_two_pair_hand
     end
 
     test "the two-pair hand with the highest second pair is stronger when the first are equal" do
-      two_pair_hand = Hand.parse_cards("Jd 5s 5h 10s 10h")
-      better_two_pair_hand = Hand.parse_cards("3d 6c 6d 10c 10d")
+      two_pair_hand = Hand.parse("Jd 5s 5h 10s 10h")
+      better_two_pair_hand = Hand.parse("3d 6c 6d 10c 10d")
 
-      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+      assert Dealer.stronger_hand(two_pair_hand, better_two_pair_hand) == better_two_pair_hand
     end
 
     test "the two-pair hand with the highest kicker is stronger when both pairs are equal" do
-      two_pair_hand = Hand.parse_cards("3d 5s 5h 10s 10h")
-      better_two_pair_hand = Hand.parse_cards("Qd 5c 5d 10c 10d")
+      two_pair_hand = Hand.parse("3d 5s 5h 10s 10h")
+      better_two_pair_hand = Hand.parse("Qd 5c 5d 10c 10d")
 
-      assert_set_equal(Dealer.stronger_hand(two_pair_hand, better_two_pair_hand), better_two_pair_hand)
+      assert Dealer.stronger_hand(two_pair_hand, better_two_pair_hand) == better_two_pair_hand
     end
 
     test "the three-of-a-kind hand with the highest three-of-a-kind is stronger" do
-      three_of_a_kind_hand = Hand.parse_cards("7h 3d 7s 4s 7c")
-      better_three_of_a_kind_hand = Hand.parse_cards("3d 4s Qs Qh Qc")
+      three_of_a_kind_hand = Hand.parse("7h 3d 7s 4s 7c")
+      better_three_of_a_kind_hand = Hand.parse("3d 4s Qs Qh Qc")
 
-      assert_set_equal(Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand), better_three_of_a_kind_hand)
+      assert Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand) == better_three_of_a_kind_hand
     end
 
     test "the straight hand with the highest rank card is stronger" do
-      straight_hand = Hand.parse_cards("6s 3s 2c 5d 4h")
-      better_straight_hand = Hand.parse_cards("Js 8s 10c 7d 9h")
+      straight_hand = Hand.parse("6s 3s 2c 5d 4h")
+      better_straight_hand = Hand.parse("Js 8s 10c 7d 9h")
 
-      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+      assert Dealer.stronger_hand(straight_hand, better_straight_hand) == better_straight_hand
     end
 
     test "the straight hand with the highest rank card is stronger when Ace is used as 1" do
-      straight_hand = Hand.parse_cards("As 2d 3c 4h 5s")
-      better_straight_hand = Hand.parse_cards("9s 10s Jc Kd Qh")
+      straight_hand = Hand.parse("As 2d 3c 4h 5s")
+      better_straight_hand = Hand.parse("9s 10s Jc Kd Qh")
 
-      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+      assert Dealer.stronger_hand(straight_hand, better_straight_hand) == better_straight_hand
     end
 
     test "the straight hand with the highest rank of Ace is stronger when Aces are used as 1 and 14" do
-      straight_hand = Hand.parse_cards("As 2d 3c 4h 5s")
-      better_straight_hand = Hand.parse_cards("As 10s Jc Kd Qh")
+      straight_hand = Hand.parse("As 2d 3c 4h 5s")
+      better_straight_hand = Hand.parse("As 10s Jc Kd Qh")
 
-      assert_set_equal(Dealer.stronger_hand(straight_hand, better_straight_hand), better_straight_hand)
+      assert Dealer.stronger_hand(straight_hand, better_straight_hand) == better_straight_hand
     end
 
     test "the flush hand with the highest rank card is stronger" do
-      flush_hand = Hand.parse_cards("8h 2h Jh 7h 4h")
-      better_flush_hand = Hand.parse_cards("3d 2d Ad 9d 4d")
+      flush_hand = Hand.parse("8h 2h Jh 7h 4h")
+      better_flush_hand = Hand.parse("3d 2d Ad 9d 4d")
 
-      assert_set_equal(Dealer.stronger_hand(flush_hand, better_flush_hand), better_flush_hand)
+      assert Dealer.stronger_hand(flush_hand, better_flush_hand) == better_flush_hand
     end
 
     test "the full-house hand with the highest three matching cards is stronger" do
-      full_house_hand = Hand.parse_cards("3s 3h 3c Ad As")
-      better_full_house_hand = Hand.parse_cards("Js Jh Jc 6d 6s")
+      full_house_hand = Hand.parse("3s 3h 3c Ad As")
+      better_full_house_hand = Hand.parse("Js Jh Jc 6d 6s")
 
-      assert_set_equal(Dealer.stronger_hand(full_house_hand, better_full_house_hand), better_full_house_hand)
+      assert Dealer.stronger_hand(full_house_hand, better_full_house_hand) == better_full_house_hand
     end
 
     test "the four-of-a-kind hand with the highest four-of-a-kind is stronger" do
-      four_of_a_kind_hand = Hand.parse_cards("3s 3h 3c 3d As")
-      better_four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d 6s")
+      four_of_a_kind_hand = Hand.parse("3s 3h 3c 3d As")
+      better_four_of_a_kind_hand = Hand.parse("4s 4h 4c 4d 6s")
 
-      assert_set_equal(Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand), better_four_of_a_kind_hand)
+      assert Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand) == better_four_of_a_kind_hand
     end
 
     test "the straight-flush hand with the highest straight-flush is stronger" do
-      straight_flush = Hand.parse_cards("Ah 3h 2h 5h 4h")
-      better_straight_flush = Hand.parse_cards("Jh 8h 10h 7h 9h")
+      straight_flush = Hand.parse("Ah 3h 2h 5h 4h")
+      better_straight_flush = Hand.parse("Jh 8h 10h 7h 9h")
 
-      assert_set_equal(Dealer.stronger_hand(straight_flush, better_straight_flush), better_straight_flush)
+      assert Dealer.stronger_hand(straight_flush, better_straight_flush) == better_straight_flush
     end
   end
 
   describe "Community card game" do
     # At the moment works out of the box without any additional code.
     test "the three-of-a-kind hand with the highest kicker is stronger when the three-of-a-kind are equal" do
-      three_of_a_kind_hand = Hand.parse_cards("7h 3d 7s Js 7c")
-      better_three_of_a_kind_hand = Hand.parse_cards("5d Jd 7s 7h 7c")
+      three_of_a_kind_hand = Hand.parse("7h 3d 7s Js 7c")
+      better_three_of_a_kind_hand = Hand.parse("5d Jd 7s 7h 7c")
 
-      assert_set_equal(Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand), better_three_of_a_kind_hand)
+      assert Dealer.stronger_hand(three_of_a_kind_hand, better_three_of_a_kind_hand) == better_three_of_a_kind_hand
     end
 
     test "the full-house hand with the highest two matching cards is stronger when the full-house are equal" do
-      full_house_hand = Hand.parse_cards("3s 3h 3c Qd Qs")
-      better_full_house_hand = Hand.parse_cards("3d 3s 3c Kd Ks")
+      full_house_hand = Hand.parse("3s 3h 3c Qd Qs")
+      better_full_house_hand = Hand.parse("3d 3s 3c Kd Ks")
 
-      assert_set_equal(Dealer.stronger_hand(full_house_hand, better_full_house_hand), better_full_house_hand)
+      assert Dealer.stronger_hand(full_house_hand, better_full_house_hand) == better_full_house_hand
     end
 
     test "the four-of-a-kind hand with the highest kicker is stronger when the four-of-a-kind are equal" do
-      four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d Js")
-      better_four_of_a_kind_hand = Hand.parse_cards("4s 4h 4c 4d Ks")
+      four_of_a_kind_hand = Hand.parse("4s 4h 4c 4d Js")
+      better_four_of_a_kind_hand = Hand.parse("4s 4h 4c 4d Ks")
 
-      assert_set_equal(Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand), better_four_of_a_kind_hand)
+      assert Dealer.stronger_hand(four_of_a_kind_hand, better_four_of_a_kind_hand) == better_four_of_a_kind_hand
     end
   end
 end

--- a/test/pokerwars/hand_test.exs
+++ b/test/pokerwars/hand_test.exs
@@ -1,4 +1,4 @@
-defmodule Pokerwars.Hand.FlushTest do
+defmodule Pokerwars.HandTest do
   use ExUnit.Case, async: true
   import Pokerwars.TestHelpers
   doctest Pokerwars.Hand

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,8 @@
 defmodule Pokerwars.TestHelpers do
   import ExUnit.Assertions
+
   def assert_score(card_strings, expected_score) do
-    cards = parse_cards(card_strings)
+    cards = Pokerwars.Hand.parse_cards(card_strings)
     score = Pokerwars.Hand.score(cards)
     assertion = (score == expected_score)
     message = "Expected score of #{print_cards(cards)} to be #{expected_score} but was #{score}"
@@ -14,10 +15,8 @@ defmodule Pokerwars.TestHelpers do
     |> Enum.join(" ")
   end
 
-  def parse_cards(card_strings) do
-    card_strings
-    |> String.split(" ")
-    |> Enum.map(&(Pokerwars.Card.parse(&1)))
+  def assert_set_equal(real_hand, expected_hand) do
+    assert Enum.into(real_hand, %MapSet{}) == Enum.into(expected_hand, %MapSet{})
   end
 end
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@ defmodule Pokerwars.TestHelpers do
   import ExUnit.Assertions
 
   def assert_score(card_strings, expected_score) do
-    cards = Pokerwars.Hand.parse_cards(card_strings)
+    cards = Pokerwars.Hand.parse(card_strings)
     score = Pokerwars.Hand.score(cards)
     assertion = (score == expected_score)
     message = "Expected score of #{print_cards(cards)} to be #{expected_score} but was #{score}"
@@ -13,10 +13,6 @@ defmodule Pokerwars.TestHelpers do
     cards
     |> Enum.map(&(Pokerwars.Card.print(&1)))
     |> Enum.join(" ")
-  end
-
-  def assert_set_equal(real_hand, expected_hand) do
-    assert Enum.into(real_hand, %MapSet{}) == Enum.into(expected_hand, %MapSet{})
   end
 end
 ExUnit.start()


### PR DESCRIPTION
Very nice dojo!
This is my solution for the comparing hands.
I added a module `Dealer` (including tests) which contains all the functions for comparing two hands.
I added documentation examples in `Hand` and `Dealer` for the `doctest`.
I moved the `parse_cards` function from the **test_helper.exs** into `Hand`.
I added function `assert_set_equal` which uses MapSet for comparing the result of the
comparison function with the expected. The last is needed because of the sorting in on of the main
function in the `Dealer`. (I didn't want to sort the expectation etc.)

What needs to be improved
- [ ] Better naming (I tried to use domain specific words like kicker etc.)
- [ ] Simplification of some of the function or the logic as hole in `Dealer`
- [x] Remove `assert_set_equal` and the MapSet dependency

Any feedback is welcome!