### PR TITLE
Add method decide_best_hand to Ranker

### DIFF
--- a/lib/pokerwars/card.ex
+++ b/lib/pokerwars/card.ex
@@ -34,16 +34,15 @@ defmodule Pokerwars.Card do
     r = card.rank
     cond do
       r in 2..10 -> Integer.to_string(r)
-      r == 11 -> 'J'
-      r == 12 -> 'Q'
-      r == 13 -> 'K'
-      r == 14 -> 'A'
+      r == 11 -> "J"
+      r == 12 -> "Q"
+      r == 13 -> "K"
+      r == 14 -> "A"
     end
   end
 
   defp print_suit(card) do
-    s = card.suit
-    case s do
+    case card.suit do
       :hearts -> "h"
       :diamonds -> "d"
       :clubs -> "c"

--- a/lib/pokerwars/permutations.ex
+++ b/lib/pokerwars/permutations.ex
@@ -1,9 +1,0 @@
-defmodule Permutations do
-  def of([]) do
-    [[]]
-  end
-
-  def of(list) do
-    for h <- list, t <- of(list -- [h]), do: [h | t]
-  end
-end

--- a/lib/pokerwars/ranker.ex
+++ b/lib/pokerwars/ranker.ex
@@ -1,12 +1,19 @@
 defmodule Pokerwars.Ranker do
-  alias Pokerwars.Helpers
+  alias Pokerwars.{Helpers, Hand}
 
   def decide_winners(hands) do
     Helpers.maxes_by(hands, &calculate_numeric_score/1)
   end
 
+  def decide_best_hand(cards) do
+    cards
+    |> Combination.combine(5)
+    |> Enum.max_by(&calculate_numeric_score/1)
+    |> Enum.sort
+  end
+
   def calculate_numeric_score(hand) do
-    score = Pokerwars.Hand.score(hand)
+    score = Hand.score(hand)
 
     score.value +
     tie_breaking_modifier(score.tie_breaking_ranks)
@@ -18,8 +25,8 @@ defmodule Pokerwars.Ranker do
 
   defp _tie_breaking_modifier([], _, result), do: result
 
-  defp _tie_breaking_modifier([ rank | others], index, result) do
-    result = result + (rank * :math.pow(100, index*-1))
-    _tie_breaking_modifier(others, index+1, result)
+  defp _tie_breaking_modifier([rank | others], index, result) do
+    result = result + (rank * :math.pow(100, index * -1))
+    _tie_breaking_modifier(others, index + 1, result)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,8 @@ defmodule Pokerwars.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:combination, "~> 0.0.3"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"combination": {:hex, :combination, "0.0.3", "746aedca63d833293ec6e835aa1f34974868829b1486b1e1cb0685f0b2ae1f41", [], [], "hexpm"}}

--- a/test/pokerwars/ranker/tie_breaking_rules_test.exs
+++ b/test/pokerwars/ranker/tie_breaking_rules_test.exs
@@ -17,6 +17,13 @@ defmodule Pokerwars.TieBreakingRulesTest do
     assert_winners([high_straight_flush, another_high_straight_flush], [another_high_straight_flush, high_straight_flush])
   end
 
+  test "An ace lower straight flush losses against any other kind of straight flush" do
+    high_straight_flush = "Jc 10c 9c 8c 7c"
+    low_straight_flush = "Ac 2c 3c 4c 5c"
+
+    assert_winners([low_straight_flush, high_straight_flush], [high_straight_flush])
+  end
+
   test "An ace high straight flush wins against a king high royal flush" do
     royal_flush = "Ac Kc Qc Jc 10c"
     king_high_straight_flush = "Kd Qd Jd 10d 9d"
@@ -101,6 +108,20 @@ defmodule Pokerwars.TieBreakingRulesTest do
     low_straight = "9h 10s Js Qh Ks"
 
     assert_winners([high_straight, low_straight], [high_straight])
+  end
+
+  test "An ace lower straight losses against any other kind of straight" do
+    high_straight = "Jc 10d 9c 8h 7c"
+    low_straight = "Ad 2h 3c 4h 5c"
+
+    assert_winners([low_straight, high_straight], [high_straight])
+  end
+
+  test "An ace high straight wins against a king high straight" do
+    high_straight = "Ad Qh Kc Jh 10c"
+    low_straight = "6c 10d 9c 8h 7c"
+
+    assert_winners([low_straight, high_straight], [high_straight])
   end
 
   test "Highested ranked three of a kind wins" do

--- a/test/pokerwars/ranker_test.exs
+++ b/test/pokerwars/ranker_test.exs
@@ -5,75 +5,100 @@ defmodule Pokerwars.RankerTest do
 
   doctest Pokerwars.Ranker
 
-  test "Order of hands does not matter" do
-    straight_flush = "5c 6c 7c 8c 9c"
-    four_of_a_kind = "Ah Ac As Ad 8c"
+  describe "Ranker.decide_winners/1" do
+    test "Order of hands does not matter" do
+      straight_flush = "5c 6c 7c 8c 9c"
+      four_of_a_kind = "Ah Ac As Ad 8c"
 
-    assert_winners([straight_flush, four_of_a_kind], [straight_flush])
-    assert_winners([four_of_a_kind, straight_flush], [straight_flush])
+      assert_winners([straight_flush, four_of_a_kind], [straight_flush])
+      assert_winners([four_of_a_kind, straight_flush], [straight_flush])
+    end
+
+    test "Straight flush beats four of a kind" do
+      straight_flush = "5c 6c 7c 8c 9c"
+      four_of_a_kind = "Ah Ac As Ad 8c"
+
+      assert_winners([straight_flush, four_of_a_kind], [straight_flush])
+    end
+
+    test "Four of a kind beats full house" do
+      four_of_a_kind = "Ah Ac As Ad 8c"
+      full_house = "Kh Kc Ks 10h 10c"
+
+      assert_winners([four_of_a_kind, full_house], [four_of_a_kind])
+    end
+
+    test "Full house beats flush" do
+      full_house = "Kh Kc Ks 10h 10c"
+      flush = "Qc 8c 6c 4c 3c"
+
+      assert_winners([full_house, flush], [full_house])
+    end
+
+    test "Flush beats straight" do
+      flush = "Qc 8c 6c 4c 3c"
+      straight = "2d 3c 4s 5d 6c"
+
+      assert_winners([flush, straight], [flush])
+    end
+
+    test "Straight beats three of a kind" do
+      straight = "2d 3c 4s 5d 6c"
+      three_of_a_kind = "Jc Jh Jd 5c 8d"
+
+      assert_winners([straight, three_of_a_kind], [straight])
+    end
+
+    test "Three of a kind beats two pair" do
+      three_of_a_kind = "Jc Jh Jd 5c 8d"
+      two_pair = "10d 10c 6s 6c Kd"
+
+      assert_winners([three_of_a_kind, two_pair], [three_of_a_kind])
+    end
+
+    test "Two pairs beats pairs" do
+      two_pair = "10d 10c 6s 6c Kd"
+      pair = "Ah Ac 8s 6h 2d"
+
+      assert_winners([two_pair, pair], [two_pair])
+    end
+
+    test "Pairs beats high card" do
+      pair = "Ah Ac 8s 6h 2d"
+      high_card = "Kh Js 10c 6h 3d"
+
+      assert_winners([pair, high_card], [pair])
+    end
+
+    test "Multiple winning hands are returned when tie occurs" do
+      pair = "Ah Ac 8s 6h 2d"
+      another_pair = "Ah Ac 8c 2h 6d"
+      high_card = "Kh Js 10c 6h 3d"
+
+      assert_winners([pair, another_pair, high_card], [another_pair, pair])
+    end
   end
 
-  test "Straight flush beats four of a kind" do
-    straight_flush = "5c 6c 7c 8c 9c"
-    four_of_a_kind = "Ah Ac As Ad 8c"
+  describe "Ranker.decide_best_hand/1" do
+    test "returns the best flush hand when given 7 cards and chooses 5" do
+      set_of_seven_cards = "Ah Qd 7h Qc Jh Qh 3h"
+      strongest_hand = "Ah 7h Jh Qh 3h"
 
-    assert_winners([straight_flush, four_of_a_kind], [straight_flush])
-  end
+      assert_best_hand(set_of_seven_cards, strongest_hand)
+    end
 
-  test "Four of a kind beats full house" do
-    four_of_a_kind = "Ah Ac As Ad 8c"
-    full_house = "Kh Kc Ks 10h 10c"
+    test "returns the best full house hand when given 7 cards and chooses 5" do
+      set_of_seven_cards = "Ah Jd Js Qd Jh Qh 3h"
+      strongest_hand = "Jd Js Qd Jh Qh"
 
-    assert_winners([four_of_a_kind, full_house], [four_of_a_kind])
-  end
+      assert_best_hand(set_of_seven_cards, strongest_hand)
+    end
 
-  test "Full house beats flush" do
-    full_house = "Kh Kc Ks 10h 10c"
-    flush = "Qc 8c 6c 4c 3c"
+    test "returns the best straight hand when given 7 cards and chooses 5" do
+      set_of_seven_cards = "As 4d 4s 3d 5h 4h 2h"
+      strongest_hand = "As 3d 5h 4h 2h"
 
-    assert_winners([full_house, flush], [full_house])
-  end
-
-  test "Flush beats straight" do
-    flush = "Qc 8c 6c 4c 3c"
-    straight = "2d 3c 4s 5d 6c"
-
-    assert_winners([flush, straight], [flush])
-  end
-
-  test "Straight beats three of a kind" do
-    straight = "2d 3c 4s 5d 6c"
-    three_of_a_kind = "Jc Jh Jd 5c 8d"
-
-    assert_winners([straight, three_of_a_kind], [straight])
-  end
-
-  test "Three of a kind beats two pair" do
-    three_of_a_kind = "Jc Jh Jd 5c 8d"
-    two_pair = "10d 10c 6s 6c Kd"
-
-    assert_winners([three_of_a_kind, two_pair], [three_of_a_kind])
-  end
-
-  test "Two pairs beats pairs" do
-    two_pair = "10d 10c 6s 6c Kd"
-    pair = "Ah Ac 8s 6h 2d"
-
-    assert_winners([two_pair, pair], [two_pair])
-  end
-
-  test "Pairs beats high card" do
-    pair = "Ah Ac 8s 6h 2d"
-    high_card = "Kh Js 10c 6h 3d"
-
-    assert_winners([pair, high_card], [pair])
-  end
-
-  test "Multiple winning hands are returned when tie occurs" do
-    pair = "Ah Ac 8s 6h 2d"
-    another_pair = "Ah Ac 8c 2h 6d"
-    high_card = "Kh Js 10c 6h 3d"
-
-    assert_winners([pair, another_pair, high_card], [another_pair, pair])
+      assert_best_hand(set_of_seven_cards, strongest_hand)
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,6 +21,13 @@ defmodule Pokerwars.TestHelpers do
     assert(assertion, message)
   end
 
+  def assert_best_hand(hand_string, expected_best_hand_string) do
+    cards = parse_cards(hand_string)
+    expected = parse_cards(expected_best_hand_string) |> Enum.sort
+
+    assert Pokerwars.Ranker.decide_best_hand(cards) == expected
+  end
+
   defp print_hands(hands) do
     hands
     |> Enum.map(fn h -> print_cards(h) end)


### PR DESCRIPTION
Add method decide_best_hand to Ranker with a few tests. Add fix for the corner case of Ace's straight and straight flush bug.
Do we need Helpers.maxes_by function?